### PR TITLE
Fix: Ensure main dashboard content area is made visible

### DIFF
--- a/html/dashboard.html
+++ b/html/dashboard.html
@@ -518,6 +518,10 @@
   if (valid) {
     document.addEventListener('DOMContentLoaded', function() {
       document.querySelector('.dashboard').style.display = '';
+      const mainContent = document.querySelector('.main-content');
+      if (mainContent) {
+        mainContent.style.display = 'block'; // Make .main-content visible
+      }
       overlay.style.display = 'none';
     });
   }


### PR DESCRIPTION
This commit addresses an issue where the dashboard page would appear completely empty after login, despite data being fetched and processed without errors.

The root cause was that the `.main-content` div, which is styled with `display: none;` by default in `css/dashboard.css`, was not being explicitly set to a visible display type (e.g., `display: block;`) by any JavaScript after your authentication.

Changes made:
- Modified the inline JavaScript in `html/dashboard.html`. Within the `DOMContentLoaded` event listener that runs after successful user validation, a line was added to set `document.querySelector('.main-content').style.display = 'block';`.

This ensures that the main container for all dashboard pages becomes visible, allowing the already active page (e.g., `#dashboard-page`) and its content to be displayed as intended.