### PR TITLE
Remove Stripe.js and backend Stripe processing for payments.

### DIFF
--- a/html/pagos.html
+++ b/html/pagos.html
@@ -258,23 +258,35 @@
                         <span class="error-message" id="cardNameError"></span>
                     </div>
                     
-                    <!-- Stripe Card Element aparecerá aquí -->
+                    <!-- Campos de Tarjeta Estándar -->
                     <div class="form-group">
-                        <label for="stripeCardElement">Datos de la Tarjeta *</label>
-                        <div id="stripeCardElement" class="StripeElement"></div>
-                        <span class="error-message" id="stripeCardError"></span>
+                        <label for="cardNumber">Número de Tarjeta *</label>
+                        <input type="text" id="cardNumber" name="cardNumber" placeholder="---- ---- ---- ----" required>
+                        <span class="error-message" id="cardNumberError"></span>
                     </div>
-
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="expiryDate">Fecha de Expiración (MM/AA) *</label>
+                            <input type="text" id="expiryDate" name="expiryDate" placeholder="MM/AA" required>
+                            <span class="error-message" id="expiryDateError"></span>
+                        </div>
+                        <div class="form-group">
+                            <label for="cvv">CVV *</label>
+                            <input type="text" id="cvv" name="cvv" placeholder="---" required>
+                            <span class="error-message" id="cvvError"></span>
+                        </div>
+                    </div>
                     <div class="form-group">
                         <input type="checkbox" id="savePaymentMethod" name="savePaymentMethod" checked>
                         <label for="savePaymentMethod">Guardar este método de pago para futuras compras</label>
                     </div>
 
-                    <div class="security-info">
-                        <div class="security-icon">🔒</div>
-                        <div class="security-text">
-                            <p><strong>Pago 100% Seguro con Stripe</strong></p>
-                            <p>Tus datos están protegidos.</p>
+                    <div class="security-info" style="background-color: #fff3cd; border: 1px solid #ffeeba; padding: 10px; margin-top: 15px; border-radius: 5px;">
+                        <div class="security-icon" style="font-size: 1.5em; margin-right: 10px;">⚠️</div>
+                        <div class="security-text" style="color: #856404;">
+                            <p><strong>Aviso Importante:</strong></p>
+                            <p>Este formulario de pago es para fines de demostración. La integración con Stripe ha sido eliminada y los pagos son simulados.</p>
+                            <p><strong>NO INGRESE DATOS REALES DE TARJETAS DE CRÉDITO.</strong></p>
                         </div>
                     </div>
                 </form>
@@ -338,8 +350,6 @@
             </button>
         </div>
     </div>
-    
-    <script src="https://js.stripe.com/v3/"></script>
     <script src="../js/pagos.js"></script>
 </body>
 </html>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,7 +47,7 @@ model MetodoPagoCliente {
   id_metodo_pago          Int     @id @default(autoincrement())
   id_cliente              Int
   cliente                 Cliente @relation(fields: [id_cliente], references: [id_cliente])
-  stripe_payment_method_id String  @unique // ID de Stripe, importante que sea único por cliente o globalmente
+  stripe_payment_method_id String? // ID de Stripe, ahora obsoleto y opcional. Se eliminó @unique.
   tipo_tarjeta            String  // ej. "visa", "mastercard"
   ultimos_cuatro_digitos  String
   fecha_expiracion        String  // ej. "12/25"


### PR DESCRIPTION
- Removes Stripe.js from pagos.html and replaces Stripe Card Element with standard input fields for card number, expiry, and CVV.
- Modifies pagos.js to handle new card input fields, removing Stripe-specific frontend logic (Elements, PaymentMethod creation).
- Disables saved payment method functionality on the frontend as it was Stripe-dependent.
- Updates PaymentController.ts:
  - processPayment now accepts raw card details and simulates payment processing instead of calling Stripe APIs.
  - createSetupIntent is disabled (returns 501).
  - listPaymentMethods and deletePaymentMethod are adjusted to remove Stripe API calls, operating on local data (though the feature is frontend-disabled).
- Makes MetodoPagoCliente.stripe_payment_method_id optional in Prisma schema.
- Adds security disclaimers in code and UI regarding the simulated payment processing and risks of handling raw card data.