### PR TITLE
Fix: Corregir bucle de redirección en checkout y error 400 al crear p…

### DIFF
--- a/frontend/js/carrito.js
+++ b/frontend/js/carrito.js
@@ -976,53 +976,10 @@ document.addEventListener('DOMContentLoaded', async function () {
   }
 });
 
-document.getElementById('confirmarCompraBtn')?.addEventListener('click', async function () {
-  const token = localStorage.getItem('token');
-  const tipo = localStorage.getItem('tipo');
-  console.log('Confirmar Compra - Token:', token ? `Yes (${token.substring(0, 10)}...)` : 'No');
-  console.log('Confirmar Compra - Tipo:', tipo);
-
-  if (!token || tipo !== 'cliente') {
-    window.CartAPI.showNotification('Debes iniciar sesión como cliente para comprar', 'error');
-    setTimeout(() => window.locatiadmin.htmlon.href = tipo === 'admin' ? '/' : '/login.html', 1500);
-    return;
-  }
-
-  try {
-    const res = await fetch('/api/cart', {
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    console.log('Confirmar Compra - Cart API Status:', res.status);
-
-    if (res.status === 401) {
-      localStorage.removeItem('token');
-      localStorage.removeItem('tipo');
-      window.CartAPI.showNotification('Sesión inválida. Por favor, inicia sesión nuevamente.', 'error');
-      setTimeout(() => window.location.href = '/login.html', 1500);
-      return;
-    }
-
-    if (!res.ok) {
-      const errorData = await res.json().catch(() => ({}));
-      console.log('Confirmar Compra - Cart API Error:', errorData);
-      throw new Error(`Failed to fetch cart: ${res.status} - ${errorData.message || 'Unknown error'}`);
-    }
-
-    const items = await res.json();
-    if (!items.length) {
-      window.CartAPI.showNotification('No hay productos en el carrito', 'error');
-      return;
-    }
-
-    window.location.href = 'pagos.html';
-  } catch (err) {
-    console.error('Confirmar Compra Error:', err);
-    window.CartAPI.showNotification(`Error: ${err.message}`, 'error');
-  }
-});
+// Eliminar el event listener redundante para confirmarCompraBtn
+// document.getElementById('confirmarCompraBtn')?.addEventListener('click', async function () {
+// ... (código eliminado) ...
+// });
 
 window.CartAPI = {
   showNotification: function (text, type, duration) {

--- a/src/controllers/OrderController.ts
+++ b/src/controllers/OrderController.ts
@@ -121,15 +121,15 @@ export async function createOrder(req: Request, res: Response, next: NextFunctio
       return res.status(403).json({ message: 'Debes verificar tu email antes de crear un pedido.' });
     }
     
-    const { id_direccion_facturacion, items } = req.body; // items: array de items con detalles avanzados
-    if (!Array.isArray(items) || items.length === 0) {
-      return res.status(400).json({ message: 'Debes enviar los items del pedido con sus detalles.' });
-    }
+    // const { id_direccion_facturacion, items } = req.body;
+    // Ya no se esperan items en el body, el servicio los obtiene del carrito.
+    const { id_direccion_facturacion } = req.body;
 
-    // items debe ser el array con la estructura avanzada esperada por el servicio
+
+    // El servicio crearPedidoDesdeCarrito ahora obtiene los items del carrito directamente.
     const newOrder = await orderService.crearPedidoDesdeCarrito(
       userId,
-      items,
+      // items, // Ya no se pasa 'items' desde aquí
       id_direccion_facturacion ? Number(id_direccion_facturacion) : undefined
     );
     res.status(201).json(newOrder);


### PR DESCRIPTION
…edido

Se identificaron dos problemas principales:
1. Un event listener duplicado en `frontend/js/carrito.js` causaba una redirección prematura a `pagos.html` sin crear el pedido, lo que llevaba a `pagos.js` a redirigir de nuevo a `carrito.html` por falta de `pedidoId`.
2. `src/controllers/OrderController.ts` esperaba incorrectamente un array de `items` en el cuerpo de la solicitud `POST /api/orders`, causando un error 400, ya que el frontend no enviaba estos datos (el servicio debe obtenerlos del carrito en la BD).

Cambios realizados:
- Se eliminó el event listener problemático en `frontend/js/carrito.js`, asegurando que la creación del pedido ocurra antes de la redirección a `pagos.html` y que el `pedidoId` se incluya en la URL.
- Se modificó `OrderController.createOrder` para que no espere `items` en el `req.body`. El `OrderService` se encarga de obtener los artículos del carrito del usuario desde la base de datos.