### PR TITLE
Fix(Syntax): Corregir error de sintaxis en OrderController

### DIFF
--- a/src/controllers/OrderController.ts
+++ b/src/controllers/OrderController.ts
@@ -121,7 +121,7 @@ export async function createOrder(req: Request, res: Response, next: NextFunctio
       return res.status(403).json({ message: 'Debes verificar tu email antes de crear un pedido.' });
     }
     
-    }
+    // Se eliminó la llave '}' extra que estaba aquí.
 
     const { id_direccion_facturacion, items } = req.body;
 


### PR DESCRIPTION
Se eliminó una llave de cierre `}` extra dentro del bloque `try` de la función `createOrder` en `src/controllers/OrderController.ts`.

Esta llave causaba errores de compilación (TS1472, TS1005, TS1128) al romper la estructura del bloque `try...catch`.
Con esta corrección, la sintaxis del archivo es válida y los errores de compilación mencionados deberían resolverse.