### PR TITLE
Feat: Enviar items del carrito con detalles al crear pedido

### DIFF
--- a/frontend/js/carrito.js
+++ b/frontend/js/carrito.js
@@ -422,13 +422,31 @@ class CartUI {
     // const idDireccionFacturacion = document.getElementById('direccionSelect')?.value;
     // const bodyData = idDireccionFacturacion ? { id_direccion_facturacion: idDireccionFacturacion } : {};
 
+    // Construir el array de items para enviar al backend
+    const itemsParaPedido = this.cartItems.map(item => {
+      const detallesVuelo = item.detalles_vuelo_json ? JSON.parse(item.detalles_vuelo_json) : {};
+      return {
+        id_producto: item.id_producto,
+        cantidad: item.cantidad,
+        // Incluir detalles adicionales si existen, asegurándose de que los nombres coincidan con lo que espera el backend
+        seleccion_clase_servicio_id: detallesVuelo.seleccion_clase_servicio_id !== undefined ? detallesVuelo.seleccion_clase_servicio_id : null,
+        seleccion_asiento_fisico_id: detallesVuelo.seleccion_asiento_fisico_id !== undefined ? detallesVuelo.seleccion_asiento_fisico_id : null,
+        selecciones_equipaje: Array.isArray(detallesVuelo.selecciones_equipaje) ? detallesVuelo.selecciones_equipaje : []
+      };
+    });
+
+    const bodyData = {
+      // id_direccion_facturacion: idDireccionFacturacion ? Number(idDireccionFacturacion) : undefined, // Descomentar si se implementa selector de dirección
+      items: itemsParaPedido
+    };
+
     fetch('/api/orders', {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${token}`,
         'Content-Type': 'application/json',
       },
-      // body: JSON.stringify(bodyData), // Enviar si es necesario
+      body: JSON.stringify(bodyData),
     })
     .then(res => {
       if (res.status === 401) {


### PR DESCRIPTION
Se modificó `frontend/js/carrito.js` para que la función `handleCheckout` recolecte los `id_producto`, `cantidad` y los detalles adicionales de vuelo (clase, asiento, equipaje) parseados desde `item.detalles_vuelo_json` para cada item en el carrito.

Estos datos se construyen en un array `items` que ahora se envía en el cuerpo de la solicitud `POST /api/orders`.

Esto asegura que el frontend provea la información detallada de los items que el backend (`OrderController` y `OrderService`) espera para crear un pedido, abordando el error 400 "Debes enviar los items del pedido con sus detalles".