### PR TITLE
Feat: Añadir footer a inicio.html y vuelos.html

### DIFF
--- a/frontend/css/inicio.css
+++ b/frontend/css/inicio.css
@@ -565,3 +565,65 @@ section {
     grid-row: 4/5;
   }
 }
+
+/* Footer Styles (copiado de autos.css) */
+.footer {
+  background: var(--black);
+  color: var(--white);
+  padding: 60px 0 20px;
+}
+
+.footer .container { /* Asegurar que la clase container dentro del footer funcione como se espera */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px; /* Padding estándar del container */
+}
+
+.footer-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 40px;
+  margin-bottom: 40px;
+}
+
+.footer-section h3,
+.footer-section h4 {
+  margin-bottom: 20px;
+  color: var(--white);
+}
+
+.footer-section ul {
+  list-style: none;
+  padding: 0; /* Resetear padding para ul */
+  margin: 0; /* Resetear margen para ul */
+}
+
+.footer-section ul li {
+  margin-bottom: 10px;
+}
+
+.footer-section a {
+  color: var(--pill);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.footer-section a:hover {
+  color: var(--red);
+}
+
+.footer-section p { /* Estilo para los párrafos dentro de footer-section */
+    line-height: 1.6;
+}
+
+.footer-section p i { /* Estilo para los íconos dentro de los párrafos */
+    margin-right: 8px;
+}
+
+.footer-bottom {
+  text-align: center;
+  padding-top: 20px;
+  border-top: 1px solid var(--pill);
+  color: var(--pill);
+}
+/* Fin de Footer Styles */

--- a/frontend/css/vuelos.css
+++ b/frontend/css/vuelos.css
@@ -549,3 +549,66 @@ body {
     padding: 3px;
   }
 }
+
+/* Footer Styles (copiado de autos.css) */
+.footer {
+  background: var(--black);
+  color: var(--white);
+  padding: 60px 0 20px;
+  margin-top: 3rem; /* Añadir un margen superior para separarlo del contenido */
+}
+
+.footer .container { /* Asegurar que la clase container dentro del footer funcione como se espera */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px; /* Padding estándar del container */
+}
+
+.footer-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 40px;
+  margin-bottom: 40px;
+}
+
+.footer-section h3,
+.footer-section h4 {
+  margin-bottom: 20px;
+  color: var(--white);
+}
+
+.footer-section ul {
+  list-style: none;
+  padding: 0; /* Resetear padding para ul */
+  margin: 0; /* Resetear margen para ul */
+}
+
+.footer-section ul li {
+  margin-bottom: 10px;
+}
+
+.footer-section a {
+  color: var(--pill);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.footer-section a:hover {
+  color: var(--red);
+}
+
+.footer-section p { /* Estilo para los párrafos dentro de footer-section */
+    line-height: 1.6;
+}
+
+.footer-section p i { /* Estilo para los íconos dentro de los párrafos */
+    margin-right: 8px;
+}
+
+.footer-bottom {
+  text-align: center;
+  padding-top: 20px;
+  border-top: 1px solid var(--pill);
+  color: var(--pill);
+}
+/* Fin de Footer Styles */

--- a/frontend/html/inicio.html
+++ b/frontend/html/inicio.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MUSIMUNDO/Travel</title>
     <link rel="stylesheet" href="../css/inicio.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css"> <!-- Añadido Font Awesome -->
 </head>
 <body>
     
@@ -232,5 +233,35 @@ document.addEventListener('DOMContentLoaded', async function() {
   }
 });
 </script>
+
+<footer class="footer">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-section">
+                <h3>MUSIMUNDO/TRAVEL</h3>
+                <p>Tu puerta de entrada a aventuras increíbles en todo el mundo.</p>
+            </div>
+            <div class="footer-section">
+                <h4>Enlaces Rápidos</h4>
+                <ul>
+                    <li><a href="inicio.html">Inicio</a></li>
+                    <li><a href="paquetes.html">Paquetes</a></li>
+                    <li><a href="vuelos.html">Vuelos</a></li>
+                    <li><a href="hotel.html">Hoteles</a></li>
+                    <li><a href="autos.html">Autos</a></li>
+                    <li><a href="info.html">Info</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Información de Contacto</h4>
+                <p><i class="fas fa-phone"></i> +1 (555) 123-4567</p>
+                <p><i class="fas fa-envelope"></i> info@musimundo.com</p>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2025 MUSIMUNDO/TRAVEL. All rights reserved.</p>
+        </div>
+    </div>
+</footer>
 </body>
 </html>

--- a/frontend/html/vuelos.html
+++ b/frontend/html/vuelos.html
@@ -100,5 +100,35 @@
 </div>
 
     <script src="../js/vuelos.js"></script>
+
+<footer class="footer">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-section">
+                <h3>MUSIMUNDO/TRAVEL</h3>
+                <p>Tu puerta de entrada a aventuras increíbles en todo el mundo.</p>
+            </div>
+            <div class="footer-section">
+                <h4>Enlaces Rápidos</h4>
+                <ul>
+                    <li><a href="inicio.html">Inicio</a></li>
+                    <li><a href="paquetes.html">Paquetes</a></li>
+                    <li><a href="vuelos.html">Vuelos</a></li>
+                    <li><a href="hotel.html">Hoteles</a></li>
+                    <li><a href="autos.html">Autos</a></li>
+                    <li><a href="info.html">Info</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Información de Contacto</h4>
+                <p><i class="fas fa-phone"></i> +1 (555) 123-4567</p>
+                <p><i class="fas fa-envelope"></i> info@musimundo.com</p>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2025 MUSIMUNDO/TRAVEL. All rights reserved.</p>
+        </div>
+    </div>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
Se añadió el footer estándar a las páginas `inicio.html` y `vuelos.html` para mantener la consistencia visual con otras páginas del sitio.

Cambios realizados:
- Se copió la estructura HTML del footer desde `autos.html`.
- Se insertó el HTML del footer en `frontend/html/inicio.html` y `frontend/html/vuelos.html`.
- Se copiaron los estilos CSS del footer desde `autos.css` a `frontend/css/inicio.css` y `frontend/css/vuelos.css` para asegurar la correcta visualización.
- Se añadió el enlace a Font Awesome en `frontend/html/inicio.html` para la correcta visualización de los íconos en el footer.