### PR TITLE
Feat: Añadir footer a hotel.html

### DIFF
--- a/frontend/css/hotel.css
+++ b/frontend/css/hotel.css
@@ -1143,3 +1143,66 @@ text-decoration: none;
     padding: 0.5rem;
   }
 }
+
+/* Footer Styles (copiado de autos.css) */
+.footer {
+  background: var(--black);
+  color: var(--white);
+  padding: 60px 0 20px;
+  margin-top: 3rem; /* Añadir un margen superior para separarlo del contenido */
+}
+
+.footer .container { /* Asegurar que la clase container dentro del footer funcione como se espera */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px; /* Padding estándar del container */
+}
+
+.footer-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 40px;
+  margin-bottom: 40px;
+}
+
+.footer-section h3,
+.footer-section h4 {
+  margin-bottom: 20px;
+  color: var(--white);
+}
+
+.footer-section ul {
+  list-style: none;
+  padding: 0; /* Resetear padding para ul */
+  margin: 0; /* Resetear margen para ul */
+}
+
+.footer-section ul li {
+  margin-bottom: 10px;
+}
+
+.footer-section a {
+  color: var(--pill);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.footer-section a:hover {
+  color: var(--red);
+}
+
+.footer-section p { /* Estilo para los párrafos dentro de footer-section */
+    line-height: 1.6;
+}
+
+.footer-section p i { /* Estilo para los íconos dentro de los párrafos */
+    margin-right: 8px;
+}
+
+.footer-bottom {
+  text-align: center;
+  padding-top: 20px;
+  border-top: 1px solid var(--pill);
+  color: var(--pill);
+}
+/* Fin de Footer Styles */

--- a/frontend/html/hotel.html
+++ b/frontend/html/hotel.html
@@ -74,5 +74,35 @@
     </div>
 
     <script src="../js/hotel.js"></script>
+
+<footer class="footer">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-section">
+                <h3>MUSIMUNDO/TRAVEL</h3>
+                <p>Tu puerta de entrada a aventuras increíbles en todo el mundo.</p>
+            </div>
+            <div class="footer-section">
+                <h4>Enlaces Rápidos</h4>
+                <ul>
+                    <li><a href="inicio.html">Inicio</a></li>
+                    <li><a href="paquetes.html">Paquetes</a></li>
+                    <li><a href="vuelos.html">Vuelos</a></li>
+                    <li><a href="hotel.html">Hoteles</a></li>
+                    <li><a href="autos.html">Autos</a></li>
+                    <li><a href="info.html">Info</a></li>
+                </ul>
+            </div>
+            <div class="footer-section">
+                <h4>Información de Contacto</h4>
+                <p><i class="fas fa-phone"></i> +1 (555) 123-4567</p>
+                <p><i class="fas fa-envelope"></i> info@musimundo.com</p>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2025 MUSIMUNDO/TRAVEL. All rights reserved.</p>
+        </div>
+    </div>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
Se añadió el footer estándar a la página `hotel.html` para mantener la consistencia visual con otras páginas del sitio.

Cambios realizados:
- Se insertó el HTML del footer en `frontend/html/hotel.html`.
- Se copiaron los estilos CSS del footer a `frontend/css/hotel.css` para asegurar la correcta visualización.
- Se verificó que `hotel.html` enlaza Font Awesome para la correcta visualización de los íconos en el footer.